### PR TITLE
Feature/active record validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "http://rubygems.org"
 
-# Specify your gem's dependencies in pesel.gemspec
 gemspec
+
+gem 'activemodel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+PATH
+  remote: .
+  specs:
+    pesel (0.9.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (5.1.3)
+      activesupport (= 5.1.3)
+    activesupport (5.1.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activemodel
+  pesel!
+
+BUNDLED WITH
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ http://github.com/macuk/pesel-plugin
 Installation
 ============
 
-gem install pesel
+`gem install pesel`
 
 Example
 =======
 
-Standalone class:
+
+### Standalone class:
+
+```ruby
 
   require 'pesel'
 
@@ -48,18 +51,16 @@ Standalone class:
   pesel.male?       # raises Pesel::NumberInvalid exception
   pesel.gender      # raises Pesel::NumberInvalid exception
   pesel.number      # raises Pesel::NumberInvalid exception
+```
 
-ActiveRecord:
+### ActiveRecord:
+
+```ruby
 
   class Person < ActiveRecord::Base
-    validate :check_pesel
-
-    private
-      def check_pesel
-        p = Pesel.new(pesel)
-        errors[:pesel] << 'Invalid PESEL number' unless p.valid?
-      end
+    validate :pesel, pesel: true
   end
+```
 
 
 Copyright (c) 2009-2010 Piotr Macuk, released under the MIT license

--- a/lib/pesel.rb
+++ b/lib/pesel.rb
@@ -1,3 +1,5 @@
+require 'pesel_validator'
+
 class Pesel
   class NumberInvalid < Exception; end
 

--- a/lib/pesel_validator.rb
+++ b/lib/pesel_validator.rb
@@ -1,0 +1,7 @@
+require 'pesel'
+
+class PeselValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, options[:message] || :invalid_pesel) unless Pesel.new(value).valid?
+  end
+end

--- a/spec/pesel_validator_spec.rb
+++ b/spec/pesel_validator_spec.rb
@@ -1,0 +1,24 @@
+require 'support/model'
+require 'pesel_validator'
+
+describe PeselValidator do
+
+  before do
+    Model.validates :field, pesel: true
+  end
+
+  let(:invalid_pesel){'00000000000'}
+  let(:valid_pesel){'75120804355'}
+
+  it 'is not valid when pesel is invalid' do
+    model = Model.new
+    model.field = invalid_pesel
+    expect(model).to_not be_valid
+  end
+
+  it 'is valid when pesel is valid' do
+    model = Model.new
+    model.field = valid_pesel
+    expect(model).to be_valid
+  end
+end

--- a/spec/support/model.rb
+++ b/spec/support/model.rb
@@ -1,0 +1,7 @@
+require 'active_model'
+
+class Model
+  include ActiveModel::Validations
+
+  attr_accessor :field
+end


### PR DESCRIPTION
PR includes:

- [x]  Add active record validator named `pesel`
- [x] Add rspec test for validator 
- [x] Improve readme file by add `.md` and fix markdown styles

Unfortunately, I didn't found the way to not include `activemodel`. To use such validator I had to inherit from `ActiveModel::EachValidator`.

_______
Btw I also tested it via `gem 'pesel', :git => 'https://github.com/piotr-galas/pesel', :branch => 'feature/active-record-validator'` in one of my rails project and It worked propertly